### PR TITLE
Update is_equal.go

### DIFF
--- a/pkg/golconda/is_equal.go
+++ b/pkg/golconda/is_equal.go
@@ -28,7 +28,7 @@ func isEqual(field string, value interface{}, isNot bool) operatorBuilder {
 						operator.Expression = "FALSE"
 					}
 				} else {
-					_vals := make([]interface{}, 0)
+					_vals := make([]interface{}, 0, s.Len()) // sets capacity upfront to avoid extra allocations in the for loop
 
 					valuesIn := buildQuestionMark(s.Len(), paramPlaceholder)
 					operator.Expression = fmt.Sprintf("%s "+sqlOperator+" (%s)", field, valuesIn)


### PR DESCRIPTION
slight performance improvement, avoiding extra allocations during append in a for loop when you already know the target size of a slice